### PR TITLE
Fix build in MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ docs/
 vids/
 test/results/
 benchmarks/
-generated/
+/generated/
+!/generated/.keep
 googletest/
 
 # Ide

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project("gpu-filters")
 # -- Config -- #
 set(DEBUG_FLAGS -"D_GLIBCXX_DEBUG")
 set(CMAKE_C_FLAGS "-std=c99")
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wconversion -Wshadow -Wall -Wextra -Wno-missing-braces -DCL_HPP_TARGET_OPENCL_VERSION=200 -DCL_HPP_MINIMUM_OPENCL_VERSION=200")
+set(CMAKE_CXX_FLAGS "-std=c++11 -Wconversion -Wshadow -Wall -Wextra -Wno-missing-braces -DCL_HPP_TARGET_OPENCL_VERSION=120 -DCL_HPP_MINIMUM_OPENCL_VERSION=120")
 # https://stackoverflow.com/questions/44942225/opencl-vector-types-cant-access-unioned-components-x-y-z-with-c11-enabled
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -U__STRICT_ANSI__")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -12,7 +12,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 # set(CMAKE_VERBOSE_MAKEFILE on)
 
 # -- Libraries -- #
-find_package( OpenCV REQUIRED )
+find_package( OpenCV REQUIRED highgui imgproc core )
 find_package( OpenCL REQUIRED )
 
 # Setup gtest


### PR DESCRIPTION
- Set OpenCL Header version to the correct one: 1.2 - [Reference](https://github.com/KhronosGroup/OpenCL-CLHPP/issues/40#issuecomment-367420071)
- Just import the necessary libraries from OpenCV for linking. If not, since OpenCV uses GoogleTest for testing, there might a clash during link time
- Keep `generated/` directory to avoid build errors from non-existing directory